### PR TITLE
Pagination markup logic change

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -289,6 +289,9 @@ s.wrapper = s.container.children('.' + s.params.wrapperClass);
 // Pagination
 if (s.params.pagination) {
     s.paginationContainer = $(s.params.pagination);
+    if (s.paginationContainer.size() > 1){
+        s.paginationContainer = s.container.find(s.params.pagination);
+    }
     if (s.params.paginationClickable) {
         s.paginationContainer.addClass('swiper-pagination-clickable');
     }


### PR DESCRIPTION
Pagination wrapper markup has to be now a children of the main container if more than one pagination container found.

If more than one pagination container elements are found in the whole DOM, we force them to be a children of the main swiper container in order to avoid possible miss-behaviour of different Swiper instances with same pagination container classes.

In this case, the flexibility of placing the pagination markup wherever you want across the DOM is lost, but gains behaviour consistency in the case of multiple swiper instances.

It's rather an unnecessary feature since you always can set different pagination-container classes while instantiating different swipers, but feels quite more comfortable to just instantiate them without  setting a specific class for each one's pagination container.

The change it's quite transparent to the library users since in the documentation and in the demos the pagination container html markup is always placed inside the container, people might not even know that you can place it outside.
